### PR TITLE
Feat: Add OpenAPI Documentation with drf-spectacular

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,4 @@ celery
 redis
 pytest-mock
 django-celery-beat
+drf-spectacular

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ asgiref==3.9.1
     # via
     #   django
     #   django-allauth
+attrs==25.3.0
+    # via
+    #   jsonschema
+    #   referencing
 billiard==4.2.1
     # via celery
 celery==5.5.3
@@ -58,6 +62,7 @@ django==5.2.5
     #   django-timezone-field
     #   djangorestframework
     #   djangorestframework-simplejwt
+    #   drf-spectacular
 django-allauth==65.11.0
     # via -r requirements.in
 django-celery-beat==2.8.1
@@ -69,7 +74,10 @@ djangorestframework==3.16.1
     #   -r requirements.in
     #   dj-rest-auth
     #   djangorestframework-simplejwt
+    #   drf-spectacular
 djangorestframework-simplejwt==5.5.1
+    # via -r requirements.in
+drf-spectacular==0.28.0
     # via -r requirements.in
 factory-boy==3.3.3
     # via -r requirements.in
@@ -81,8 +89,14 @@ identify==2.6.13
     # via pre-commit
 idna==3.10
     # via requests
+inflection==0.5.1
+    # via drf-spectacular
 iniconfig==2.1.0
     # via pytest
+jsonschema==4.25.1
+    # via drf-spectacular
+jsonschema-specifications==2025.4.1
+    # via jsonschema
 kombu==5.5.4
     # via celery
 nodeenv==1.9.1
@@ -128,11 +142,21 @@ python-dateutil==2.9.0.post0
 python-decouple==3.8
     # via -r requirements.in
 pyyaml==6.0.2
-    # via pre-commit
+    # via
+    #   drf-spectacular
+    #   pre-commit
 redis==6.4.0
     # via -r requirements.in
+referencing==0.36.2
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
 requests==2.32.5
     # via -r requirements.in
+rpds-py==0.27.1
+    # via
+    #   jsonschema
+    #   referencing
 ruff==0.12.8
     # via -r requirements.in
 six==1.17.0
@@ -140,13 +164,17 @@ six==1.17.0
 sqlparse==0.5.3
     # via django
 typing-extensions==4.15.0
-    # via cron-descriptor
+    # via
+    #   cron-descriptor
+    #   referencing
 tzdata==2025.2
     # via
     #   django
     #   django-celery-beat
     #   faker
     #   kombu
+uritemplate==4.2.0
+    # via drf-spectacular
 urllib3==2.5.0
     # via requests
 vine==5.1.0

--- a/src/petcare/settings.py
+++ b/src/petcare/settings.py
@@ -39,6 +39,7 @@ THIRD_PARTY_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "django_celery_beat",
+    "drf_spectacular",
 ]
 
 LOCAL_APPS = [
@@ -171,6 +172,7 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",
     ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 if DEBUG:

--- a/src/petcare/urls.py
+++ b/src/petcare/urls.py
@@ -1,4 +1,9 @@
 from django.urls import include, path
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 from src.apps.accounts.admin import petcare_admin_site
 
@@ -11,4 +16,15 @@ urlpatterns = [
     path("api/v1/health/", include("src.apps.health.urls")),
     path("api/v1/schedule/", include("src.apps.schedule.urls")),
     path("api/v1/store/", include("src.apps.store.urls")),
+    path("api/v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/v1/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "api/v1/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
 ]


### PR DESCRIPTION
### What’s New
- Integrated `drf-spectacular` to automatically generate an OpenAPI 3 schema for the project's API.
- Exposed new endpoints for interactive documentation:
  - `/api/v1/schema/swagger-ui/` (Swagger UI)
  - `/api/v1/schema/redoc/` (ReDoc)

### Why
- To provide clear, interactive, and auto-updating documentation for the API.
- This improves the developer experience for both frontend and backend developers, making it easier to understand and interact with the available endpoints.

### Testing
- Verified that the server runs correctly after adding the new configurations.
- Confirmed that the Swagger UI is accessible and correctly displays all the registered API endpoints.

### Notes
- This is a non-breaking addition and has no impact on the existing API functionality.