### PR TITLE
Refactor: Standardize API ViewSet Permissions

### DIFF
--- a/src/apps/pets/views.py
+++ b/src/apps/pets/views.py
@@ -1,5 +1,7 @@
-from rest_framework import permissions, viewsets
+from rest_framework import viewsets
 from rest_framework.permissions import IsAuthenticated
+
+from src.petcare.permissions import IsStaffOrReadOnly
 
 from .models import Breed, Pet
 from .serializers import BreedSerializer, PetSerializer
@@ -8,14 +10,7 @@ from .serializers import BreedSerializer, PetSerializer
 class BreedViewSet(viewsets.ModelViewSet):
     queryset = Breed.objects.all()
     serializer_class = BreedSerializer
-
-    def get_permissions(self):
-        if self.action in ["list", "retrieve"]:
-            self.permission_classes = [IsAuthenticated]
-        else:
-            self.permission_classes = [permissions.IsAdminUser]
-
-        return super().get_permissions()
+    permission_classes = [IsStaffOrReadOnly]
 
 
 class PetViewSet(viewsets.ModelViewSet):

--- a/src/apps/schedule/views.py
+++ b/src/apps/schedule/views.py
@@ -5,6 +5,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from src.petcare.permissions import IsStaffOrReadOnly
+
 from .models import Appointment, Service, TimeSlot
 from .serializers import AppointmentSerializer, ServiceSerializer, TimeSlotSerializer
 
@@ -48,13 +50,7 @@ class AvailableSlotsView(APIView):
 class ServiceViewSet(viewsets.ModelViewSet):
     queryset = Service.objects.all().order_by("name")
     serializer_class = ServiceSerializer
-
-    def get_permissions(self):
-        if self.action in ["list", "retrieve"]:
-            self.permission_classes = [IsAuthenticated]
-        else:
-            self.permission_classes = [permissions.DjangoModelPermissions]
-        return super().get_permissions()
+    permission_classes = [IsStaffOrReadOnly]
 
 
 class TimeSlotViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
### Summary
- This PR applies the custom `IsStaffOrReadOnly` permission class to the `ServiceViewSet` and `BreedViewSet`.
- It standardizes the permission logic for general data endpoints across the API, ensuring consistency and maintainability.

### Testing
- Manually verified that non-staff authenticated users can perform GET requests but receive a 403 Forbidden error on POST/PUT/DELETE requests to `/api/v1/schedule/services/` and `/api/v1/pets/breeds/`.
- Confirmed that staff users can perform all actions on these endpoints.
- Confirmed that user-specific endpoints (like `/api/v1/pets/pets/`) remain unchanged and fully functional for authenticated users.