### PR TITLE
Chore: Add Pytest Pre-Push Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,4 @@ repos:
       entry: pytest
       language: system
       types: [python]
-      stages: [push]
+      stages: [pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-# .pre-commit-config.yaml
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
@@ -10,9 +9,18 @@ repos:
     - id: check-added-large-files
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  # Versão do Ruff a ser utilizada
+
   rev: v0.12.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
     - id: ruff-format
+
+- repo: local
+  hooks:
+    - id: pytest
+      name: pytest
+      entry: pytest
+      language: system
+      types: [python]
+      stages: [push]


### PR DESCRIPTION
### Summary
- Configures `pre-commit` to run the `pytest` test suite on the `pre-push` git hook.
- This acts as a local quality gate to prevent pushing code that fails tests.

### Testing
- Verified locally by running `pre-commit install --hook-type pre-push`.
- Confirmed that `git push` now triggers the test suite and aborts the push if any test fails.