### PR TITLE
feat(core): Implement Redis Caching for API Endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,6 @@ jobs:
         TESTING: "True"
         DATABASE_URL: "postgres://test_user:test_password@localhost:5432/test_db"
         CELERY_BROKER_URL: "redis://localhost:6379/0"
+        CACHE_URL: "redis://localhost:6379/1"
         SECRET_KEY: "a-secret-key-for-testing-purposes-only"
         DEBUG: "False"

--- a/src/apps/store/views.py
+++ b/src/apps/store/views.py
@@ -1,3 +1,5 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 from rest_framework import status, viewsets
 from rest_framework.permissions import IsAdminUser
 from rest_framework.renderers import JSONRenderer
@@ -15,11 +17,19 @@ class CategoryViewSet(viewsets.ModelViewSet):
     serializer_class = CategorySerializer
     permission_classes = [IsStaffOrReadOnly]
 
+    @method_decorator(cache_page(60 * 15))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
 
 class BrandViewSet(viewsets.ModelViewSet):
     queryset = Brand.objects.all()
     serializer_class = BrandSerializer
     permission_classes = [IsStaffOrReadOnly]
+
+    @method_decorator(cache_page(60 * 15))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 class ProductViewSet(viewsets.ModelViewSet):

--- a/src/petcare/settings.py
+++ b/src/petcare/settings.py
@@ -186,6 +186,18 @@ if DEBUG:
 CELERY_BROKER_URL = config("CELERY_BROKER_URL", default="redis://redis:6379/0")
 CELERY_RESULT_BACKEND = config("CELERY_RESULT_BACKEND", default="redis://redis:6379/0")
 
+
+# ==============================================================================
+# CACHE SETTINGS
+# ==============================================================================
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": "redis://redis:6379/1",
+    }
+}
+
+
 # ==============================================================================
 # EMAIL SETTINGS
 # ==============================================================================

--- a/src/petcare/settings.py
+++ b/src/petcare/settings.py
@@ -193,7 +193,7 @@ CELERY_RESULT_BACKEND = config("CELERY_RESULT_BACKEND", default="redis://redis:6
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": "redis://redis:6379/1",
+        "LOCATION": config("CACHE_URL", default="redis://redis:6379/1"),
     }
 }
 


### PR DESCRIPTION
# What’s New
- Django's cache backend is now configured to use **Redis**, connecting to database **1** to keep data separate from Celery.  
- The `@cache_page` decorator has been applied to the **list methods** of `CategoryViewSet` and `BrandViewSet`, caching their responses for **15 minutes**.  

# Why
- To significantly improve the performance and reduce the response time of frequently accessed, rarely updated API endpoints.  
- To decrease the load on the database for these list views.  
- This establishes a caching pattern that can be extended to other parts of the application as needed.  

# Testing
- Verified functionality by observing a **significant drop in response time** in the browser's *Network* tab on subsequent requests.  
- Confirmed that **cache keys** are correctly created in Redis database 1 by inspecting it with `redis-cli`.  

# Notes
- Initial configuration issues were debugged, leading to a **simplified and correct `CACHES` setting** that uses Django's native Redis backend.  
