### PR TITLE
Perf: Optimize API ViewSets to Prevent N+1 Queries

### DIFF
--- a/src/apps/accounts/views.py
+++ b/src/apps/accounts/views.py
@@ -10,7 +10,7 @@ from .serializers import CustomerSerializer
     description="Endpoints for retrieving customer (tutor) information.",
 )
 class CustomerViewSet(viewsets.ModelViewSet):
-    queryset = Customer.objects.all().order_by("id")
+    queryset = Customer.objects.select_related("user").order_by("id")
     serializer_class = CustomerSerializer
 
     @extend_schema(summary="List all customers (staff only)")

--- a/src/apps/health/views.py
+++ b/src/apps/health/views.py
@@ -16,7 +16,9 @@ class HealthRecordViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        return HealthRecord.objects.filter(pet__owner__user=user)
+        return HealthRecord.objects.filter(pet__owner__user=user).select_related(
+            "pet", "created_by"
+        )
 
     def perform_create(self, serializer):
         serializer.save(created_by=self.request.user)

--- a/src/apps/pets/views.py
+++ b/src/apps/pets/views.py
@@ -47,13 +47,16 @@ class BreedViewSet(viewsets.ModelViewSet):
     description="Endpoints for users to manage their own pets.",
 )
 class PetViewSet(viewsets.ModelViewSet):
-    queryset = Pet.objects.all().order_by("name")
     serializer_class = PetSerializer
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         user = self.request.user
-        return Pet.objects.filter(owner__user=user).order_by("name")
+        return (
+            Pet.objects.filter(owner__user=user)
+            .select_related("breed", "owner__user")
+            .order_by("name")
+        )
 
     def perform_create(self, serializer):
         tutor = self.request.user.customer_profile

--- a/src/apps/schedule/views.py
+++ b/src/apps/schedule/views.py
@@ -156,7 +156,10 @@ class AppointmentViewSet(viewsets.ModelViewSet):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        return Appointment.objects.filter(pet__owner__user=self.request.user)
+        user = self.request.user
+        return Appointment.objects.filter(pet__owner__user=user).select_related(
+            "pet", "service"
+        )
 
     def perform_create(self, serializer):
         serializer.save()

--- a/src/apps/store/tests/test_tasks.py
+++ b/src/apps/store/tests/test_tasks.py
@@ -113,6 +113,7 @@ class TestStoreReportTasks:
     def test_generate_daily_promotions_report(self, mocker):
         # Arrange
         mocked_now = timezone.make_aware(timezone.datetime(2025, 8, 26, 10, 0))
+        mocker.patch("django.utils.timezone.now", return_value=mocked_now)
         mocker.patch("django.utils.timezone.localdate", return_value=mocked_now.date())
         send_mail_mock = mocker.patch("src.apps.store.tasks.send_mail")
 
@@ -144,6 +145,7 @@ class TestStoreReportTasks:
     def test_generate_daily_promotions_report_no_data(self, mocker):
         # Arrange
         mocked_now = timezone.make_aware(timezone.datetime(2025, 8, 26, 10, 0))
+        mocker.patch("django.utils.timezone.now", return_value=mocked_now)
         mocker.patch("django.utils.timezone.localdate", return_value=mocked_now.date())
         send_mail_mock = mocker.patch("src.apps.store.tasks.send_mail")
 


### PR DESCRIPTION
### What's New
This PR introduces performance optimizations across several API ViewSets to resolve N+1 query issues. It also includes a fix for a related test that was failing due to improper time mocking.

- **Query Optimization**: Applied `select_related` to the querysets in `CustomerViewSet`, `HealthRecordViewSet`, `PetViewSet`, and `AppointmentViewSet`. This ensures that related objects are fetched in a single database query, drastically improving response times for list endpoints.
- **Test Fix**: Corrected the `test_generate_daily_promotions_report` by mocking `timezone.now()` in addition to `timezone.localdate`, making the test deterministic.

### Why
To improve the overall performance and scalability of the API by reducing database load and preventing potential bottlenecks as the amount of data grows.

### Testing
- All existing tests pass successfully.
- Ran `./scripts/test.sh` locally to confirm 100% pass rate.
- The CI pipeline should confirm these results.

### PR Review Checklist
- [ ] Code follows project conventions.
- [ ] Tests added/updated for new functionality.
- [ ] Documentation updated.
- [ ] No breaking changes (or they are properly documented).
- [ ] Environment dependencies documented.
- [ ] CI/CD approvals.