### PR TITLE
feat(dashboard): Implement custom admin dashboard

### DIFF
--- a/src/petcare/settings.py
+++ b/src/petcare/settings.py
@@ -8,7 +8,7 @@ from celery.schedules import crontab
 from decouple import config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 # ==============================================================================
@@ -130,9 +130,9 @@ USE_TZ = True
 # ==============================================================================
 
 STATIC_URL = "static/"
-STATIC_ROOT = BASE_DIR.parent / "staticfiles"
+STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [
-    BASE_DIR / "static",
+    BASE_DIR / "src/static",
 ]
 
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
@@ -291,7 +291,7 @@ LOGGING = {
         },
         "json_file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": BASE_DIR.parent / "logs/petcare.json.log",
+            "filename": BASE_DIR / "logs/petcare.json.log",
             "maxBytes": 1024 * 1024 * 5,
             "backupCount": 5,
             "formatter": "json_formatter",

--- a/src/templates/admin/dashboard.html
+++ b/src/templates/admin/dashboard.html
@@ -1,0 +1,129 @@
+{% extends "admin/base_site.html" %}
+{% load static i18n %}
+
+{% block extrastyle %}
+{{ block.super }}
+<style>
+    .dashboard-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 20px;
+        margin-bottom: 20px;
+    }
+
+    .dashboard-card {
+        background-color: var(--body-bg);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 20px;
+    }
+
+    .dashboard-card h2 {
+        font-size: 1.2rem;
+        margin-top: 0;
+        color: var(--header-link-color);
+    }
+
+    .dashboard-card .metric {
+        font-size: 2.5rem;
+        font-weight: 600;
+        color: var(--header-bg);
+    }
+
+    .dashboard-full-width {
+        grid-column: 1 / -1;
+    }
+
+    .dashboard-table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    .dashboard-table th,
+    .dashboard-table td {
+        text-align: left;
+        padding: 8px;
+        border-bottom: 1px solid var(--border-color);
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+    <h1>Dashboard PetCare</h1>
+
+    <div class="dashboard-grid">
+        <div class="dashboard-card">
+            <h2>Faturamento de Hoje</h2>
+            <p class="metric">R$ {{ revenue_today|floatformat:2 }}</p>
+        </div>
+        <div class="dashboard-card">
+            <h2>Agendamentos Confirmados para Hoje</h2>
+            <p class="metric">{{ appointments_today }}</p>
+        </div>
+    </div>
+
+    <div class="dashboard-grid">
+        <div class="dashboard-card dashboard-full-width">
+            <h2>Faturamento (Últimos 7 Dias)</h2>
+            <canvas id="revenueChart"></canvas>
+        </div>
+    </div>
+
+    <div class="dashboard-grid">
+        <div class="dashboard-card dashboard-full-width">
+            <h2>Produtos Mais Vendidos Hoje</h2>
+            {% if top_products %}
+            <table class="dashboard-table">
+                <thead>
+                    <tr>
+                        <th>Produto</th>
+                        <th>Quantidade Vendida</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for product in top_products %}
+                    <tr>
+                        <td>{{ product.lot__product__name }}</td>
+                        <td>{{ product.total_sold }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p>Nenhum produto foi vendido hoje.</p>
+            {% endif %}
+        </div>
+    </div>
+
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const ctx = document.getElementById('revenueChart').getContext('2d');
+        const revenueChart = new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: {{ chart_labels| safe }},
+        datasets: [{
+            label: 'Faturamento (R$)',
+            data: {{ chart_values| safe }},
+        backgroundColor: 'rgba(75, 192, 192, 0.5)',
+        borderColor: 'rgba(75, 192, 192, 1)',
+        borderWidth: 1
+            }]
+        },
+        options: {
+        scales: {
+            y: {
+                beginAtZero: true
+            }
+        }
+    }
+    });
+});
+</script>
+
+{% endblock %}


### PR DESCRIPTION
### What's New
- This PR introduces a custom, data-driven dashboard on the Django Admin homepage, replacing the default index page.
- **Backend:** A custom `index` view was added to `PetCareAdminSite`, performing database aggregations to calculate key metrics.
- **Frontend:** A new `dashboard.html` template was created, using `Chart.js` to render a 7-day revenue chart.
- **Key Metrics Displayed:**
    - Card: Total revenue for the current day.
    - Card: Number of confirmed appointments for the current day.
    - Chart: Bar chart of daily revenue over the last 7 days.
    - Table: Top 5 best-selling products for the current day.

### Why
- To provide administrators with immediate, actionable insights into the business's daily performance directly within their primary management tool.
- To demonstrate advanced Django Admin customization skills, including view overriding, custom template rendering, and complex database queries (`.aggregate`, `.annotate`).
- To create a more professional and value-added experience for the admin user.

### Testing
- [x] The full static analysis suite (`mypy`, `ruff`) passes.
- [x] The complete test suite (`pytest`) passes, ensuring no regressions were introduced.
- [x] Manual testing was performed on the Django Admin dashboard, confirming that all metrics and the chart render correctly with seed data.
- [x] A foundational `BASE_DIR` configuration bug was identified and fixed as part of this work, making the entire project's pathing more robust.

### Checklist
- [x] The code follows the project's conventions.
- [x] No breaking changes.
- [x] CI/CD approvals.