### PR TITLE
chore(deploy): Enable HTTPS using Certbot and Nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,9 +15,11 @@ services:
     image: nginx:1.25-alpine
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
       - staticfiles:/usr/src/app/staticfiles
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     depends_on:
       - web
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,17 +3,39 @@ upstream petcare_server {
 }
 
 server {
-  listen 80;
-  server_name brunadev.com petcare.brunadev.com;
+    listen 80;
+    server_name brunadev.com petcare.brunadev.com;
 
-  location /static/ {
-    alias /usr/src/app/staticfiles/;
-  }
 
-  location / {
-    proxy_pass http://petcare_server;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $host;
-    proxy_redirect off;
-  }
+    if ($host = petcare.brunadev.com) {
+        return 301 https://$host$request_uri;
+    }
+    if ($host = brunadev.com) {
+        return 301 https://$host$request_uri;
+    }
+    return 404;
+}
+
+
+server {
+    listen 443 ssl;
+    server_name brunadev.com petcare.brunadev.com;
+
+
+    ssl_certificate /etc/letsencrypt/live/brunadev.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/brunadev.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+
+    location /static/ {
+        alias /usr/src/app/staticfiles/;
+    }
+
+    location / {
+        proxy_pass http://petcare_server;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
 }


### PR DESCRIPTION
### What's New
- Updates `nginx.conf` with SSL configuration generated by Certbot. This includes setting up the server to listen on port 443, pointing to the Let's Encrypt SSL certificates, and adding recommended security parameters.
- Implements a permanent (301) redirect for all HTTP traffic on port 80 to the secure HTTPS version on port 443.
- Modifies `docker-compose.prod.yml`:
    - Exposes port `443` on the Nginx container to handle incoming secure traffic.
    - Mounts the host's `/etc/letsencrypt` directory into the Nginx container as a read-only volume, allowing it to access the SSL certificates.

### Why
This PR finalizes the production infrastructure by securing the application with HTTPS. Serving the site over a secure connection is a standard industry practice that protects data, builds user trust, and removes the "Not Secure" warning from browsers. This change elevates the project to a production-grade level, making it a more professional and compelling portfolio piece.

### Testing
- [x] `pytest` passes locally.
- [x] CI pipeline passes.
- [x] Manual deployment verification: The configuration has been successfully applied to the AWS EC2 instance. The site is now accessible via `https://petcare.brunadev.com` with a valid SSL certificate, and HTTP traffic is correctly redirected.

### Checklist
- [x] Code follows conventions.
- [x] No breaking changes to the local development environment.
- [x] CI/CD approvals.