### PR TITLE
fix(deploy): configure CSRF settings for production environment

### DIFF
--- a/src/petcare/settings.py
+++ b/src/petcare/settings.py
@@ -17,11 +17,33 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = config("SECRET_KEY")
 DEBUG = config("DEBUG", default=False, cast=bool)
+
 ALLOWED_HOSTS = config(
     "ALLOWED_HOSTS",
     default="127.0.0.1",
     cast=lambda v: [s.strip() for s in v.split(",")],
 )
+
+
+# ==============================================================================
+# SECURITY SETTINGS FOR PRODUCTION (HTTPS)
+# ==============================================================================
+
+CSRF_TRUSTED_ORIGINS = [
+    "https://brunadev.com",
+    "https://petcare.brunadev.com",
+]
+
+
+if not DEBUG:
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+
+# ==============================================================================
+# APPLICATION DEFINITION
+# ==============================================================================
 
 # Application definition
 DJANGO_APPS = [


### PR DESCRIPTION
### What's New
- Added `CSRF_TRUSTED_ORIGINS` to `settings.py` to whitelist the production domains (`petcare.brunadev.com`, `brunadev.com`).
- Set `CSRF_COOKIE_SECURE` and `SESSION_COOKIE_SECURE` to `True` when `DEBUG=False` to ensure security cookies are only transmitted over HTTPS.
- Configured the `SECURE_PROXY_SSL_HEADER` to allow Django to correctly identify secure requests when running behind the Nginx reverse proxy.

### Why
This change is critical to resolve the "CSRF verification failed (403)" error that was occurring in the production environment. Without these settings, Django's security middleware incorrectly blocks all POST requests over HTTPS, making the Django Admin unusable for creating or modifying data. This fix ensures the application is secure and fully functional on AWS.

### Testing
- [x] pytest passes
- [x] Manual tests performed on the production environment by creating an admin group, confirming the fix.
- [x] The CSRF 403 error bug is resolved.

### Checklist
- [x] Code follows project conventions and Django's best practices for deployment.
- [x] No breaking changes for the local development environment.
- [x] CI/CD pipeline passes successfully.