### PR TITLE
fix(deploy): Finalize Production Deployment with Permission Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY . .
 COPY ./entrypoint.prod.sh /app/entrypoint.prod.sh
 RUN chmod +x /app/entrypoint.prod.sh
 
+RUN chown -R appuser:appuser /app
+
 EXPOSE 8000
 
 USER appuser


### PR DESCRIPTION
### What's New
This PR introduces the final and definitive fix for the application's startup issues in the production environment.

- **`Dockerfile`:** Added a `RUN chown -R appuser:appuser /app` command. This transfers ownership of all application files to the non-root `appuser`.

### Why
Following the implementation of the `entrypoint.prod.sh` script, a `PermissionError: [Errno 13] Permission denied` was identified in the startup logs. The error occurred because the application, running as the secure `appuser`, did not have the necessary permissions to write log files in the `/app/logs` directory, which was owned by `root`.

This change resolves the permission error, which was the final blocker preventing the application from starting correctly. With this fix, the entire startup sequence orchestrated by the entrypoint script can now execute successfully.

### Testing
- [x] pytest passes
- [x] The `Dockerfile` change was tested on the production server, confirming that the `PermissionError` is resolved.
- [x] The application now starts successfully, and the website is accessible without any `502 Bad Gateway` errors.
- [x] The startup and permission bugs are fully resolved.

### Checklist
- [x] Code follows project conventions and enterprise-level deployment and security practices.
- [x] No breaking changes introduced.
- [x] CI/CD pipeline is expected to pass.