### PR TITLE
Fix: Correct Production Deployment Errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,5 @@ RUN chown -R appuser:appuser /app
 
 EXPOSE 8000
 
-USER appuser
 
 CMD ["/app/entrypoint.prod.sh"]

--- a/entrypoint.prod.sh
+++ b/entrypoint.prod.sh
@@ -6,10 +6,15 @@ echo "Waiting for services to be ready..."
 sleep 5
 
 echo "Running database migrations..."
-python manage.py migrate --noinput
+python manage.py migrate
+
+
+echo "Updating static files volume ownership..."
+chown -R appuser:appuser /app/staticfiles
 
 echo "Collecting static files..."
-python manage.py collectstatic --noinput
+su-exec appuser python manage.py collectstatic --no-input
 
-echo "Starting Gunicorn server..."
-exec gunicorn src.petcare.wsgi:application --bind 0.0.0.0:8000
+echo "Starting Gunicorn..."
+
+exec su-exec appuser gunicorn src.petcare.wsgi:application --bind 0.0.0.0:8000

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,7 +29,7 @@ server {
 
 
     location /static/ {
-        alias /usr/src/app/staticfiles/;
+        alias /app/staticfiles/;
     }
 
     location / {

--- a/src/petcare/urls.py
+++ b/src/petcare/urls.py
@@ -5,8 +5,8 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-from apps.core.views import LandingPageView
 from src.apps.accounts.admin import petcare_admin_site
+from src.apps.core.views import LandingPageView
 
 urlpatterns = [
     path("", LandingPageView.as_view(), name="landing-page"),


### PR DESCRIPTION
### What's New
- **Initial Fix:** Corrected a `ModuleNotFoundError` in `src/petcare/urls.py` and an incorrect Nginx `alias` path for static files.
- **Enhanced Fix:** Refactored the `Dockerfile` and `entrypoint.prod.sh` to definitively solve file permission errors during `collectstatic`.
    - The entrypoint script now runs as `root` to correctly `chown` the static files volume.
    - Privileges are then dropped using `su-exec` to run the Gunicorn application server as the non-root `appuser`, ensuring a secure setup.

### Why
This PR fixes a series of critical deployment issues:
1.  The `ModuleNotFoundError` was causing the `web` container to crash, resulting in a **502 Bad Gateway** error.
2.  The `PermissionError` during `collectstatic` was also preventing the container from starting, caused by a conflict between the non-root `appuser` and volumes owned by `root`.

The final solution implements a robust, industry-standard pattern for handling permissions in Docker, ensuring reliable and secure deployments.

### Testing
- [x] `pytest` passes
- [x] Manual tests (Verified after deployment that the site loads correctly)
- [x] Bugs resolvidos (502 Bad Gateway and Permission Denied on `collectstatic`)

### Checklist
- [x] Code follows conventions
- [x] No breaking changes
- [x] CI/CD approvals