### PR TITLE
fix(celery): Configure Database Scheduler for Celery Beat

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -40,7 +40,7 @@ services:
 
   celery_beat:
     build: .
-    command: celery -A petcare beat -l info
+    command: celery -A petcare beat -l info --scheduler django_celery_beat.schedulers:DatabaseScheduler
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
### What's New
- Added the `--scheduler django_celery_beat.schedulers:DatabaseScheduler` flag to the `celery_beat` service command in `docker-compose.prod.yml`.

### Why
- The Celery Beat service was running but not loading the scheduled tasks from the Django database. This flag explicitly tells the scheduler to use the database as its source of truth.
- This change fixes the critical issue of periodic tasks (like applying expiration discounts) not being executed in the production environment.

### Testing
- [x] The fix was validated locally by inspecting the `celery_beat` container logs, which confirmed the `DatabaseScheduler` was active and sending tasks.
- [ ] After merging and deploying, the production logs for the `celery_beat` service must be checked to confirm it is functioning as expected.

### Checklist
- [x] Code follows conventions.
- [x] No breaking changes to other services.
- [x] CI/CD pipeline passes.