### PR TITLE
fix(dashboard): Use Timezone-Aware Range for Sales Query

### DIFF
--- a/src/apps/accounts/admin.py
+++ b/src/apps/accounts/admin.py
@@ -84,10 +84,13 @@ class PetCareAdminSite(admin.AdminSite):
     index_template = "admin/dashboard.html"
 
     def index(self, request, extra_context=None):
-        today = timezone.now().date()
+        now = timezone.now()
+        today = now.date()
+        start_of_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        end_of_day = start_of_day + timedelta(days=1)
         start_of_week = today - timedelta(days=6)
 
-        sales_today = Sale.objects.filter(created_at__date=today)
+        sales_today = Sale.objects.filter(created_at__range=(start_of_day, end_of_day))
         revenue_today = sales_today.aggregate(total=Sum("total_value"))["total"] or 0
 
         appointments_today = Appointment.objects.filter(


### PR DESCRIPTION
### What's New
- The dashboard query for "today's sales" and "top products today" has been refactored.
- It now uses a `created_at__range` filter with explicit, timezone-aware `datetime` objects for the start and end of the current day.

### Why
- The previous `__date` filter was not correctly fetching sales made late in the day, likely due to subtle timezone discrepancies between the application (America/Sao_Paulo) and the database server (UTC).
- This more explicit range query is more robust and ensures data is fetched accurately regardless of the underlying server timezones.